### PR TITLE
feat(): rename all opponents

### DIFF
--- a/contents/myludo.ts
+++ b/contents/myludo.ts
@@ -185,8 +185,20 @@ async function patch() {
                 current.name = overridenUser && overridenUser.myludoUser && overridenUser.myludoUser.length > 0 ? overridenUser.myludoUser : current.name;
             });
 
+            // même correspondance appliquée au snapshot d'origine, pour que la détection de doublon reste cohérente
+            // avec l'historique Myludo même si renameAllOpponents est aussi actif
+            data.originalPlayers?.forEach(current => {
+                const overridenUser = configuration.users.find(o => o.bgaUser === current.name);
+                current.name = overridenUser && overridenUser.myludoUser && overridenUser.myludoUser.length > 0 ? overridenUser.myludoUser : current.name;
+            });
+
             await loadPlays((plays => {
-                const hasBeenPlayed = myludoHelper.hasBeenAlreadyPlayed(data, plays);
+                // la détection de doublon doit se baser sur les noms d'origine (avant renameAllOpponents),
+                // sinon elle ne reconnaît plus les parties déjà saisies sur Myludo avec les vrais pseudos
+                const hasBeenPlayed = myludoHelper.hasBeenAlreadyPlayed(
+                    { ...data, players: data.originalPlayers ?? data.players },
+                    plays
+                );
 
                 addPlayButton.item(0).click();
 

--- a/core/constants.ts
+++ b/core/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_OPPONENTS_BASE_NAME = "BGA";

--- a/core/models/configuration.ts
+++ b/core/models/configuration.ts
@@ -4,6 +4,8 @@ import type { MappedUser } from "./mappedUser";
 export class Configuration {
     customizeCurrentPlayer?: boolean;
     customCurrentPlayerName: string;
+    renameAllOpponents?: boolean;
+    customOpponentsBaseName: string;
     fillPlace?: boolean;
     place: string;
     autoSubmit: boolean;

--- a/core/models/table.ts
+++ b/core/models/table.ts
@@ -3,6 +3,8 @@ import type { Player } from "./player";
 export class Table {
     tableId: string;
     players: Player[];
+    // snapshot des joueurs avant renommage par renameAllOpponents, utilisé pour la détection de doublon sur Myludo
+    originalPlayers?: Player[];
     end: Date;
     isCooperative: boolean;
     isSolo: boolean;

--- a/core/services/boardGameArenaService.ts
+++ b/core/services/boardGameArenaService.ts
@@ -1,4 +1,5 @@
 import { sendToBackground } from "@plasmohq/messaging";
+import { DEFAULT_OPPONENTS_BASE_NAME } from "~core/constants";
 import { BackgroundMessages } from "~core/models/backgroundMessages";
 import type { Friend } from "~core/models/boardGameArena/friendsResponse";
 import type { Table } from "~core/models/table";
@@ -35,14 +36,19 @@ export default class boardGameArenaService {
             duration: realTimeMode.includes(response.data.options[200]?.value) ? Math.floor(Number(response.data.result.time_duration) / 60) : undefined
         };
 
+        let currentPlayerIndex = -1;
+
         response.data.result.player.forEach((item) => {
             let playerName = item.name;
+            const isCurrentPlayer = playerName === connectedUser.nickname;
 
-            if (playerName === connectedUser.nickname &&
+            if (isCurrentPlayer &&
                 configuration.customizeCurrentPlayer &&
                 configuration.customCurrentPlayerName) {
                 playerName = configuration.customCurrentPlayerName;
             }
+
+            if (isCurrentPlayer) currentPlayerIndex = table.players.length;
 
             table.players.push({
                 name: playerName,
@@ -50,6 +56,22 @@ export default class boardGameArenaService {
                 rank: item.gamerank ? Number(item.gamerank) : null
             });
         });
+
+        // snapshot avant renommage, pour que la détection de doublon Myludo reste fiable
+        table.originalPlayers = table.players.map(p => ({ ...p }));
+
+        if (configuration.renameAllOpponents &&
+            !table.isSolo &&
+            currentPlayerIndex !== -1) {
+            const baseName = configuration.customOpponentsBaseName && configuration.customOpponentsBaseName.length > 0 ? configuration.customOpponentsBaseName : DEFAULT_OPPONENTS_BASE_NAME;
+
+            table.players
+                .filter((_, index) => index !== currentPlayerIndex)
+                .sort((a, b) => (b.score ?? Number.MIN_SAFE_INTEGER) - (a.score ?? Number.MIN_SAFE_INTEGER))
+                .forEach((opponent, rank) => {
+                    opponent.name = rank === 0 ? baseName : `${baseName}_${rank}`;
+                });
+        }
 
         return table;
     }

--- a/core/services/configurationService.ts
+++ b/core/services/configurationService.ts
@@ -1,6 +1,7 @@
 import { Storage } from "@plasmohq/storage";
 import games from "data-env:assets/games.json";
 import { v4 as uuidv4 } from 'uuid';
+import { DEFAULT_OPPONENTS_BASE_NAME } from "~core/constants";
 import { Configuration } from "~core/models/configuration";
 import type { MappedGame } from "~core/models/mappedGame";
 
@@ -22,6 +23,9 @@ export default class configurationService {
 
         configuration.autoUpdateUsers = configuration.autoUpdateUsers !== undefined ? configuration.autoUpdateUsers : true;
         configuration.addTableLink = configuration.addTableLink !== undefined ? configuration.addTableLink : true;
+
+        configuration.renameAllOpponents = configuration.renameAllOpponents !== undefined ? configuration.renameAllOpponents : false;
+        configuration.customOpponentsBaseName = configuration.customOpponentsBaseName && configuration.customOpponentsBaseName.length > 0 ? configuration.customOpponentsBaseName : DEFAULT_OPPONENTS_BASE_NAME;
 
         configuration.users = configuration.users ? configuration.users.sort((a, b) => (a.bgaUser < b.bgaUser ? -1 : 1)) : [];
         configuration.users.forEach((element) => { element.id = uuidv4() });

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -116,6 +116,15 @@
     "configurationCustomCurrentNamePlayerLabel": {
         "message": "Nom"
     },
+    "configurationRenameAllOpponentsLabel": {
+        "message": "Renommer tous les adversaires"
+    },
+    "configurationRenameAllOpponentsTitle": {
+        "message": "Ce paramètre conserve tous les joueurs mais renomme chaque adversaire (le meilleur score prend ce nom, les suivants un suffixe _1, _2...) lors de la saisie de la partie sur Myludo"
+    },
+    "configurationCustomOpponentsBaseNameLabel": {
+        "message": "Nom"
+    },
     "dayMode": {
         "message": "Basculer en mode jour"
     },

--- a/popup/components/Configuration.tsx
+++ b/popup/components/Configuration.tsx
@@ -127,6 +127,33 @@ export default function Configuration({ configuration, onConfigurationUpdated }:
                     </div>
                 }
 
+                <Divider />
+
+                <ListItemButton onClick={() => onClick("renameAllOpponents")}>
+                    <ListItemIcon>
+                        <Switch checked={configuration.renameAllOpponents} size='small' />
+                    </ListItemIcon>
+                    <ListItemText
+                        className='configuration-item'
+                        primary={<span className='configuration-item-primary'>{chrome.i18n.getMessage("configurationRenameAllOpponentsLabel")}</span>}
+                        secondary={<span className='configuration-item-secondary'>{chrome.i18n.getMessage("configurationRenameAllOpponentsTitle")}</span>}
+                    />
+                </ListItemButton>
+                {configuration.renameAllOpponents &&
+                    <div>
+                        <TextField
+                            className='configuration-textfield'
+                            value={configuration.customOpponentsBaseName}
+                            name='customOpponentsBaseName'
+                            onChange={onChange}
+                            size="small"
+                            label={chrome.i18n.getMessage("configurationCustomOpponentsBaseNameLabel")}
+                            variant='standard'
+                            inputProps={{ style: { fontSize: 14 } }}
+                        />
+                    </div>
+                }
+
             </List>
         </div>
     )


### PR DESCRIPTION
Ajoute une option de configuration "renameAllOpponents" pour éviter de polluer la liste de joueurs Myludo avec les adversaires occasionnels croisés en ligne. Garde tous les participants, mais renomme chaque adversaire (tout le monde sauf moi) selon un nom de base personnalisable : le meilleur score prend ce nom tel quel, les suivants (triés par score) reçoivent un suffixe incrémenté (BGA, BGA_1, BGA_2...). Désactivée par défaut, ne s'applique pas aux parties solo/coopératives.

Corrige aussi la détection de doublon (hasBeenAlreadyPlayed()) pour qu'elle continue de comparer les vrais pseudos BGA en interne (via un instantané des joueurs pris avant renommage), même quand cette option est activée — sinon la validation automatique pouvait resoumettre silencieusement une partie déjà saisie.


rename all opponents
Adds a "renameAllOpponents" configuration option to avoid bloating the Myludo player list with one-off online opponents. Keeps every participant, but renames each opponent (everyone except me) based on a customizable base name: the best score takes that name as-is, the others (sorted by score) get an incrementing suffix (BGA, BGA_1, BGA_2...). Disabled by default, skips solo/cooperative games.

Also fixes hasBeenAlreadyPlayed() duplicate detection so it keeps comparing the real BGA usernames internally (via a players snapshot taken before renaming), even when this option is enabled - otherwise autoSubmit could silently resubmit an already-logged game once names no longer match the Myludo history.